### PR TITLE
Add instructions to install required packages for running the  benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ To run the benchmark locally:
     ```
 
 3. **Run benchmark on a dataset**:
+    Make sure the required packages are installed:
+
+    ```bash
+    sudo apt install squashfuse gocryptfs fuse-overlayfs  
+    ```
+
+    Run the benchmark:
+
     ```bash
     ./run.sh /path/to/dataset/dir
     ```


### PR DESCRIPTION
I solved the error message `container creation failed: mount hook function failure: mount overlay->/usr/local/var/apptainer/mnt/session/final error: while mounting overlay: can't mount overlay filesystem to /usr/local/var/apptainer/mnt/session/final: invalid argument` described in #12 by installing the following packages (on Ubuntu):

* squashfuse 
* gocryptfs 
* fuse-overlayfs  

I'm not familar with overlay filesystems, so not sure if all three are needed, but at least the error went away after installing these for me.

This PR adds this information to the README.