### PR TITLE
Enable run pi HelixNovo locally

### DIFF
--- a/algorithms/pi-HelixNovo/container.def
+++ b/algorithms/pi-HelixNovo/container.def
@@ -1,5 +1,5 @@
 Bootstrap: docker
-From: ytp22/pi-helixnovo-env:v1
+From: m.daocloud.io/docker.io/python:3.8
 
 %files
     # Copy algorithm-related files to a separate dir /algo.
@@ -11,10 +11,99 @@ From: ytp22/pi-helixnovo-env:v1
     # Download algorithm source code & Download algorithm weights
     cd /algo
     git clone https://github.com/PHOENIXcenter/pi-HelixNovo.git -b pi-HelixNovo-for-DenovoBenchmarks
+    rm pi-HelixNovo/MSV000081142-epoch-5-step-800000.ckpt
+    curl -L -o pi-HelixNovo/MSV000081142-epoch-5-step-800000.ckpt https://media.githubusercontent.com/media/PHOENIXcenter/pi-HelixNovo/refs/heads/pi-HelixNovo-for-DenovoBenchmarks/MSV000081142-epoch-5-step-800000.ckpt?download=true
+    pip install \
+    absl-py==1.4.0 \
+    aiohttp==3.8.4 \
+    aiosignal==1.3.1 \
+    appdirs==1.4.4 \
+    async-timeout==4.0.2 \
+    attrs==22.2.0 \
+    cachetools==5.3.0 \
+    certifi==2022.12.7 \
+    cffi==1.15.1 \
+    charset-normalizer==3.0.1 \
+    click==8.1.3 \
+    contourpy==1.0.7 \
+    cycler==0.11.0 \
+    deprecated==1.2.13 \
+    einops==0.6.0 \
+    fastobo==0.12.2 \
+    fonttools==4.38.0 \
+    frozenlist==1.3.3 \
+    fsspec==2023.1.0 \
+    google-auth==2.16.2 \
+    google-auth-oauthlib==0.4.6 \
+    grpcio==1.51.3 \
+    h5py==3.8.0 \
+    idna==3.4 \
+    importlib-metadata==6.0.0 \
+    importlib-resources==5.12.0 \
+    joblib==1.2.0 \
+    kiwisolver==1.4.4 \
+    lark==1.1.5 \
+    lightning-utilities==0.7.1 \
+    llvmlite==0.39.1 \
+    lxml==4.9.2 \
+    markdown==3.4.1 \
+    markupsafe==2.1.2 \
+    matplotlib==3.7.0 \
+    multidict==6.0.4 \
+    numba==0.56.4 \
+    numpy==1.23.5 \
+    nvidia-cublas-cu11==11.10.3.66 \
+    nvidia-cuda-nvrtc-cu11==11.7.99 \
+    nvidia-cuda-runtime-cu11==11.7.99 \
+    nvidia-cudnn-cu11==8.5.0.96 \
+    oauthlib==3.2.2 \
+    packaging==23.0 \
+    pandas==1.5.3 \
+    pillow==9.4.0 \
+    protobuf==4.22.1 \
+    psutil==5.9.4 \
+    pyasn1==0.4.8 \
+    pyasn1-modules==0.2.8 \
+    pycparser==2.21 \
+    pygithub==1.58.0 \
+    pyjwt==2.6.0 \
+    pynacl==1.5.0 \
+    pyparsing==3.0.9 \
+    pyteomics==4.5.6 \
+    python-dateutil==2.8.2 \
+    pytorch-lightning==1.9.3 \
+    pytz==2022.7.1 \
+    pyyaml==6.0 \
+    requests==2.28.2 \
+    requests-oauthlib==1.3.1 \
+    rsa==4.9 \
+    scikit-learn==1.2.1 \
+    scipy==1.10.1 \
+    setuptools==67.6.0 \
+    six==1.16.0 \
+    spectrum-utils==0.4.1 \
+    tensorboard==2.12.0 \
+    tensorboard-data-server==0.7.0 \
+    tensorboard-plugin-wit==1.8.1 \
+    threadpoolctl==3.1.0 \
+    torch==1.13.1 \
+    torchmetrics==0.11.1 \
+    tqdm==4.64.1 \
+    typing-extensions==4.5.0 \
+    urllib3==1.26.14 \
+    werkzeug==2.2.3 \
+    wheel==0.40.0 \
+    wrapt==1.14.1 \
+    yarl==1.8.2 \
+    zipp==3.15.0 \
+    setuptools_scm==4.0.0 \
+    -i https://pypi.tuna.tsinghua.edu.cn/simple
+
+
 
 %post
     # Make sure make_predictions.sh file is executable.
-    chmod +x algorithms/pi-HelixNovo/make_predictions.sh
+    chmod +x /algo/make_predictions.sh
 
 # Run algorithm and convert outputs.
 # Data is expected to be mounted into /algo/data dir.

--- a/algorithms/pi-HelixNovo/container.def
+++ b/algorithms/pi-HelixNovo/container.def
@@ -1,5 +1,5 @@
 Bootstrap: docker
-From: m.daocloud.io/docker.io/python:3.8
+From: python:3.8
 
 %files
     # Copy algorithm-related files to a separate dir /algo.

--- a/algorithms/pi-HelixNovo/make_predictions.sh
+++ b/algorithms/pi-HelixNovo/make_predictions.sh
@@ -21,7 +21,6 @@ fi
 
 # Use tag variables to specify de novo algorithm
 # for the particular dataset properties
-conda activate main_env
 cd /algo
 echo "Processing mgf files:"
 python pi-HelixNovo/main.py --mode=denovo --config=pi-HelixNovo/config.yaml --gpu=$device --output=outputs.csv --peak_path="$@"/*.mgf --model=pi-HelixNovo/MSV000081142-epoch-5-step-800000.ckpt


### PR DESCRIPTION
root@ytp-Redmi-G-2022:/home/denovo_benchmarks# sudo ./run.sh sample_data/9_species_human
Recalculate all algorithm outputs: false
Processing dataset: 9_species_human (sample_data/9_species_human)
sample_data/9_species_human/mgf/151009_exo4_1.mgf
./outputs/9_species_human/pi-HelixNovo_output.csv
Processing algorithm: pi-HelixNovo
RUN ALGORITHM
Processing mgf files:
......
Predicting DataLoader 0: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 345/345 [07:40<00:00,  1.34s/it]Finished!
Predicting DataLoader 0: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 345/345 [07:40<00:00,  1.34s/it]
EXPORT PREDICTIONS
EVALUATE PREDICTIONS
......
Evaluating results for 9_species_human.
Reference proteome length: 2 proteins.
{5: 43.005814}
{5: 43.005814, 4: 57.021464}
{5: 43.005814, 4: 57.021464, 7: 0.984016}
{5: 43.005814, 4: 57.021464, 7: 0.984016, 385: -17.026549}
{5: 43.005814, 4: 57.021464, 7: 0.984016, 385: -17.026549, 1: 42.010565}
{5: 43.005814, 4: 57.021464, 7: 0.984016, 385: -17.026549, 1: 42.010565, 35: 15.994915}
/home/denovo_benchmarks/evaluate.py:182: FutureWarning:

Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '['LPELLAQALSK' 'HLFLPSSYK' 'QQPQKFPEALR' ... 'CPCCCEECCK' 'CPCCCDCCCR'
 'EEEEEECEEECEECEECCECCEECEESE']' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.

100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 11016/11016 [00:00<00:00, 1759767.40it/s]
Traceback (most recent call last):
  File "/home/denovo_benchmarks/evaluate.py", line 256, in <module>
    precision = np.cumsum(aa_matches_pred[sort_idx]) / np.arange(
ValueError: operands could not be broadcast together with shapes (3738,) (65364,) 