### PR TITLE
Add containerised deployment for the Streamlit dashboard

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,44 @@
+# Keep the build context small. The dashboard needs dashboard.py,
+# datasets_info.py and results/ — everything below belongs to the benchmarking
+# pipeline, which does not run in this image.
+#
+# Without this file the context is ~370 MB; with it, ~47 MB.
+
+.git
+.github
+.devcontainer
+
+# Benchmarking pipeline: Apptainer definitions, demo spectra, evaluation code
+algorithms/
+sample_data/
+evaluation/
+tests/
+evaluation.def
+
+# Pipeline entrypoints and helpers
+run.sh
+run_dataset.sh
+run_split.sh
+run_test.sh
+build_apptainer_images.sh
+augment_predictions.sh
+create_dataset.py
+dataset_utils.py
+dataset_config.py
+update_tags.py
+test_output_format.py
+
+# Deployment files themselves are not needed inside the image
+Dockerfile
+.dockerignore
+docker-compose.deployment.yaml
+deploy.sh
+
+# Local/editor cruft
+__pycache__/
+*.py[cod]
+.venv/
+venv/
+.env
+.env.template
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Streamlit dashboard for the de novo benchmarking results.
+#
+# Only the dashboard runs here. The benchmarking pipeline itself needs Apptainer
+# and GPUs and is excluded from the build context via .dockerignore.
+
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# curl is needed by the container healthcheck
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY ./requirements-dashboard.txt /app/requirements-dashboard.txt
+
+RUN pip3 install --no-cache-dir -r requirements-dashboard.txt
+
+# Brings in dashboard.py, datasets_info.py and results/
+COPY . /app
+
+EXPOSE 8501
+
+HEALTHCHECK CMD curl --fail http://localhost:8501/_stcore/health
+
+ENTRYPOINT ["streamlit", "run", "dashboard.py", "--server.port=8501", "--server.address=0.0.0.0"]

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Build images
+docker compose -f docker-compose.deployment.yaml build
+
+# Start services
+docker compose -f docker-compose.deployment.yaml up -d

--- a/docker-compose.deployment.yaml
+++ b/docker-compose.deployment.yaml
@@ -1,0 +1,33 @@
+services:
+  denovo-benchmarks-streamlit-app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: bittremieuxlab/denovo-benchmarks-streamlit-app:latest
+    restart: unless-stopped
+
+    # No host port is published: the reverse proxy reaches the container over
+    # the shared bittremieuxlab-public network.
+    expose:
+      - "8501"
+
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "http://localhost:8501/_stcore/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+    environment:
+      STREAMLIT_SERVER_PORT: 8501
+      STREAMLIT_SERVER_ADDRESS: 0.0.0.0
+      STREAMLIT_SERVER_HEADLESS: "true"
+      STREAMLIT_SERVER_ENABLE_CORS: "false"
+      STREAMLIT_SERVER_ENABLE_XSRF_PROTECTION: "false"
+      TZ: Europe/Brussels
+
+    networks:
+      - bittremieuxlab-public
+
+networks:
+  bittremieuxlab-public:
+    external: true

--- a/docker-compose.deployment.yaml
+++ b/docker-compose.deployment.yaml
@@ -21,8 +21,6 @@ services:
       STREAMLIT_SERVER_PORT: 8501
       STREAMLIT_SERVER_ADDRESS: 0.0.0.0
       STREAMLIT_SERVER_HEADLESS: "true"
-      STREAMLIT_SERVER_ENABLE_CORS: "false"
-      STREAMLIT_SERVER_ENABLE_XSRF_PROTECTION: "false"
       TZ: Europe/Brussels
 
     networks:

--- a/requirements-dashboard.txt
+++ b/requirements-dashboard.txt
@@ -1,0 +1,13 @@
+# Dependencies for the Streamlit dashboard (dashboard.py) only.
+#
+# The root requirements.txt targets the benchmarking pipeline. On Streamlit
+# Community Cloud, streamlit was installed automatically and pandas came in as
+# one of its dependencies, so neither needed to be listed. A container image
+# gets no such treatment, so both are pinned explicitly here.
+#
+# Versions are pinned so that rebuilds are reproducible: deploy.sh rebuilds the
+# image on every deployment, and an unpinned dependency would let an unrelated
+# deploy silently pull a breaking major version. Bump these deliberately.
+streamlit==1.61.1
+pandas==3.0.5
+plotly==6.5.2


### PR DESCRIPTION
Adds the files needed to run `dashboard.py` on Asimov, alongside the lab's other web projects. **No existing files are modified.**

## How it works

`kafka-cluster-ansible` clones this repo as the `webuser` account and runs `./deploy.sh`, which builds the image and starts the container on the shared `bittremieuxlab-public` network. nginx reaches it by service name and serves it at **denovobenchmarks.bittremieuxlab.org**.

## Files

| File | Purpose |
|---|---|
| `Dockerfile` | `python:3.12-slim`, runs `streamlit run dashboard.py` |
| `docker-compose.deployment.yaml` | container on the shared network, healthcheck, `restart: unless-stopped` |
| `deploy.sh` | build + `up -d` (the entrypoint Ansible calls) |
| `requirements-dashboard.txt` | pinned dashboard dependencies |
| `.dockerignore` | keeps the benchmarking pipeline out of the build context |

## Note on dependencies

The root `requirements.txt` lists only `plotly`. That was fine on Streamlit Community Cloud, which installs `streamlit` automatically and pulls in `pandas` as one of its dependencies. A container image gets no such treatment, so both are listed explicitly.

They live in a **separate** `requirements-dashboard.txt` so the root file stays dedicated to the benchmarking pipeline.

Versions are pinned (`streamlit==1.61.1`, `pandas==3.0.5`, `plotly==6.5.2`) because `deploy.sh` rebuilds the image on every deployment — unpinned, an unrelated deploy months from now could silently pull a breaking major version. **Trade-off:** dashboard dependencies now need deliberate upgrades rather than arriving automatically as they did on Community Cloud.

## Note on results

`results/` is copied into the image at build time, so refreshed benchmark results reach the dashboard by committing them and redeploying. There's no live path from the HPC.

## Testing

Built and ran locally from these exact files:

- `./deploy.sh` runs clean end to end; container reports **healthy**
- **62 datasets, 258 result CSVs** parsed with no failures
- Dashboard renders **195 plots / 3347 traces** with correct AUC values, no console errors
- Reachable over the shared network by service name (the nginx upstream): **HTTP 200**
- Build context reduced ~370 MB → ~47 MB

Not yet verified: the build on Asimov itself (built on arm64 locally, x86 there — same base image and pure-Python wheels).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added containerized deployment for the Streamlit benchmarking dashboard.
  * Added Docker Compose configuration with health checks, restart handling, and network integration.
  * Added a deployment command for building and starting the dashboard services.
  * Added pinned dashboard dependencies to support reproducible deployments.

* **Improvements**
  * Reduced the Docker build context by excluding development and local artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->